### PR TITLE
fix: rename detail row definition attribute

### DIFF
--- a/pbi_core/ssas/model_tables/detail_row_definition/detail_row_definition.py
+++ b/pbi_core/ssas/model_tables/detail_row_definition/detail_row_definition.py
@@ -31,7 +31,7 @@ class DetailRowDefinition(SsasEditableRecord):
 
     modified_time: datetime.datetime
 
-    _commands: BaseCommands = PrivateAttr(default_factory=lambda: SsasCommands.detail_row_defintion)
+    _commands: BaseCommands = PrivateAttr(default_factory=lambda: SsasCommands.detail_row_definition)
 
     @classmethod
     def _db_type_name(cls) -> str:

--- a/pbi_core/ssas/server/utils.py
+++ b/pbi_core/ssas/server/utils.py
@@ -29,7 +29,7 @@ class SsasCommands:
     column_permission = BaseCommands.new(commands["ColumnPermissions"])
     culture = RenameCommands.new(commands["Cultures"])
     data_source = RenameCommands.new(commands["DataSources"])
-    detail_row_defintion = BaseCommands.new(commands["DetailRowsDefinition"])
+    detail_row_definition = BaseCommands.new(commands["DetailRowsDefinition"])
     expression = RenameCommands.new(commands["Expressions"])
     extended_property = RenameCommands.new(commands["ExtendedProperties"])
     format_string_definition = BaseCommands.new(commands["FormatStringDefinitions"])


### PR DESCRIPTION
## Summary
- rename `detail_row_defintion` attribute to `detail_row_definition`
- update references to new attribute name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62245f68483329788603f8463c984