### PR TITLE
Add structlog logging across modules

### DIFF
--- a/pbi_core/main.py
+++ b/pbi_core/main.py
@@ -7,8 +7,26 @@ logger = get_logger()
 
 
 def column_finder(c: Column, reference: ModelColumnReference) -> bool:
-    return c.explicit_name == reference.column and c.table().name == reference.table
+    match = c.explicit_name == reference.column and c.table().name == reference.table
+    logger.debug(
+        "column_finder",
+        column=c.explicit_name,
+        table=c.table().name,
+        reference_table=reference.table,
+        reference_column=reference.column,
+        match=match,
+    )
+    return match
 
 
 def measure_finder(m: Measure, reference: ModelMeasureReference) -> bool:
-    return m.name == reference.measure and m.table().name == reference.table
+    match = m.name == reference.measure and m.table().name == reference.table
+    logger.debug(
+        "measure_finder",
+        measure=m.name,
+        table=m.table().name,
+        reference_table=reference.table,
+        reference_measure=reference.measure,
+        match=match,
+    )
+    return match

--- a/pbi_core/ssas/model_tables/base/base_ssas_table.py
+++ b/pbi_core/ssas/model_tables/base/base_ssas_table.py
@@ -81,10 +81,12 @@ class SsasTable(BaseValidation, IdBase):
 
     def query_dax(self, query: str, db_name: str | None = None) -> None:
         """Helper function to remove the ``.tabular_model.server`` required to run a DAX query from an SSAS element."""
+        logger.debug("Executing DAX query", query=query, db_name=db_name)
         self.tabular_model.server.query_dax(query, db_name=db_name)
 
     def query_xml(self, query: str, db_name: str | None = None) -> BeautifulSoup:
         """Helper function to remove the ``.tabular_model.server`` required to run an XML query from an SSAS element."""
+        logger.debug("Executing XML query", query=query, db_name=db_name)
         return self.tabular_model.server.query_xml(query, db_name)
 
     @staticmethod
@@ -114,6 +116,11 @@ class SsasTable(BaseValidation, IdBase):
 
         Entity schemas can be found at `pbi_core/ssas/server/command_templates/schema`
         """
+        logger.debug(
+            "Rendering XML command",
+            db_name=db_name,
+            fields=list(values.keys()),
+        )
         xml_row = SsasTable._get_row_xml(values, command)
         xml_entity_definition = command.entity_template.render(rows=xml_row)
         return command.base_template.render(db_name=db_name, entity_def=xml_entity_definition)

--- a/pbi_core/ssas/setup/config.py
+++ b/pbi_core/ssas/setup/config.py
@@ -34,10 +34,15 @@ class PbiCoreStartupConfig(BaseValidation):
 
 
 def get_startup_config() -> PbiCoreStartupConfig:
+    config_path = PACKAGE_DIR / "local" / "settings.json"
     try:
-        with (PACKAGE_DIR / "local" / "settings.json").open("r") as f:
-            return PbiCoreStartupConfig.model_validate_json(f.read())
+        logger.info("Loading startup configuration", path=config_path)
+        with config_path.open("r") as f:
+            cfg = PbiCoreStartupConfig.model_validate_json(f.read())
+            logger.info("Loaded startup configuration", path=config_path)
+            return cfg
     except FileNotFoundError as e:
+        logger.error("Startup configuration not found", path=config_path)
         msg = textwrap.dedent("""
 
         When loading a pbix file with pbi_core, the package needs one of the following:


### PR DESCRIPTION
## Summary
- log report loading, saving, and model cleansing in LocalReport
- add debug helpers for column and measure finder utilities
- instrument SSAS tabular model sync operations, startup config loader, and SSAS table command helpers with structlog

## Testing
- `pre-commit run --files pbi_core/report/local/main.py pbi_core/main.py pbi_core/ssas/server/tabular_model/tabular_model.py pbi_core/ssas/setup/config.py pbi_core/ssas/model_tables/base/base_ssas_table.py` *(command not found)*
- `pip install pre-commit` *(proxy 403 Forbidden)*
- `pip install bandit[toml]` *(proxy 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6229cec1c83329ea1ff61cefe101c